### PR TITLE
Add decoupled interface to CORDIC

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Pipelined generic CORDIC
 
 Generic pipelined CORDIC that supports rotation/vectoring and circular/hyperbolic modes. Due to the pipelined nature, it will generate quite a lot of hardware, but will have a throughput of one operation per clock cycle.
+
+`Decoupled` interface allows full sample-by-sample flow control.
 ## Example
 ```
 ./configure && make config=basic CordicTop

--- a/src/main/scala/AdderSubtractor.scala
+++ b/src/main/scala/AdderSubtractor.scala
@@ -38,6 +38,25 @@ class AdderSubtractor(bits: Int) extends Module {
   io.S := S_vec.asTypeOf(SInt(bits.W))
 }
 
+/** Adder Subtractor combinatorial module. 
+  * Calculates either addition or 
+  * subtraction depending on input D.
+  *
+  * D = false -> Addition
+  * 
+  * D = true -> Subtraction
+  *
+  * @param bits
+  *   How many bits inputs and outputs are
+  */
+class AdderSubtractorAlt(bits: Int) extends Module {
+  val io    = IO(AdderSubtractorIO(bits))
+
+  val op_b = Mux(io.D, ~io.B + 1.S, io.B)
+
+  io.S := io.A + op_b
+}
+
 object AdderSubtractor extends App {
   // These lines generate the Verilog output
   (new ChiselStage).execute(

--- a/src/main/scala/CordicCore.scala
+++ b/src/main/scala/CordicCore.scala
@@ -1,21 +1,21 @@
 package cordic
 
 import chisel3._
-import chisel3.util.{ValidIO, RegEnable, Fill, Cat}
+import chisel3.util.{ValidIO, DecoupledIO, RegEnable, Fill, Cat}
 import chisel3.stage.{ChiselStage}
 import chisel3.stage.ChiselGeneratorAnnotation
 
 case class CordicCoreIO(dataWidth: Int) extends Bundle {
 
-  val in = Input(ValidIO(new Bundle {
+  val in = Flipped(DecoupledIO(new Bundle {
     val cordic  = CordicBundle(dataWidth)
     val control = CordicCoreControl()
   }))
 
-  val out = Output(ValidIO(new Bundle {
+  val out = DecoupledIO(new Bundle {
     val cordic  = CordicBundle(dataWidth)
     val control = CordicCoreControl()
-  }))
+  })
 
 }
 
@@ -60,18 +60,20 @@ class CordicCore(mantissaBits: Int,
   val totalIterations = if (enableHyperbolic) iterations + nRepeats
                         else                  iterations
 
-  val inRegs     = RegEnable(io.in.bits, io.in.valid)
+  val inRegs     = RegEnable(io.in.bits, io.in.valid && io.out.ready)
   val inValidReg = RegInit(false.B)
-  inValidReg := io.in.valid
+  inValidReg := io.in.valid && io.out.ready
 
   val adders = Seq.fill(totalIterations)(Seq.fill(3)(Module(new AdderSubtractorAlt(mantissaBits + fractionBits))))
 
   val inWires      = Seq.fill(totalIterations)(Wire(chiselTypeOf(io.in)))
   val outWires     = Seq.fill(totalIterations)(Wire(chiselTypeOf(io.in)))
-  val pipelineRegs = Seq.tabulate(totalIterations)(i => RegEnable(outWires(i).bits, outWires(i).valid))
+  val pipelineRegs = Seq.tabulate(totalIterations)(i => RegEnable(outWires(i).bits, outWires(i).valid && io.out.ready))
   val validRegs    = Seq.tabulate(totalIterations)(i => RegInit(false.B))
 
-  validRegs.zip(outWires).map { case (validReg, outWire) => validReg := outWire.valid }
+  validRegs.zip(outWires).map { case (validReg, outWire) => validReg := outWire.valid && io.out.ready }
+  inWires.foreach(_.ready := false.B)
+  outWires.foreach(_.ready := false.B)
   inWires(0).bits  := inRegs
   inWires(0).valid := inValidReg
 
@@ -192,6 +194,7 @@ class CordicCore(mantissaBits: Int,
 
   io.out.bits  := pipelineRegs(totalIterations - 1)
   io.out.valid := validRegs(totalIterations - 1)
+  io.in.ready  := io.out.ready
 }
 
 object CordicCore extends App {
@@ -199,7 +202,7 @@ object CordicCore extends App {
   // These lines generate the Verilog output
   (new ChiselStage).execute(
     { Array() ++ args },
-    Seq(ChiselGeneratorAnnotation(() => new CordicCore(4, 12, 14,
+    Seq(ChiselGeneratorAnnotation(() => new CordicCore(4, 12, 16,
                                                        "fixed-point", true, true, true, true)))
   )
 

--- a/src/main/scala/CordicCore.scala
+++ b/src/main/scala/CordicCore.scala
@@ -64,7 +64,7 @@ class CordicCore(mantissaBits: Int,
   val inValidReg = RegInit(false.B)
   inValidReg := io.in.valid
 
-  val adders = Seq.fill(totalIterations)(Seq.fill(3)(Module(new AdderSubtractor(mantissaBits + fractionBits))))
+  val adders = Seq.fill(totalIterations)(Seq.fill(3)(Module(new AdderSubtractorAlt(mantissaBits + fractionBits))))
 
   val inWires      = Seq.fill(totalIterations)(Wire(chiselTypeOf(io.in)))
   val outWires     = Seq.fill(totalIterations)(Wire(chiselTypeOf(io.in)))

--- a/src/main/scala/CordicCore.scala
+++ b/src/main/scala/CordicCore.scala
@@ -60,18 +60,16 @@ class CordicCore(mantissaBits: Int,
   val totalIterations = if (enableHyperbolic) iterations + nRepeats
                         else                  iterations
 
-  val inRegs     = RegEnable(io.in.bits, io.in.valid && io.out.ready)
-  val inValidReg = RegInit(false.B)
-  inValidReg := io.in.valid && io.out.ready
+  val inRegs     = RegEnable(io.in.bits, io.out.ready)
+  val inValidReg = RegEnable(io.in.valid, false.B, io.out.ready)
 
   val adders = Seq.fill(totalIterations)(Seq.fill(3)(Module(new AdderSubtractorAlt(mantissaBits + fractionBits))))
 
   val inWires      = Seq.fill(totalIterations)(Wire(chiselTypeOf(io.in)))
   val outWires     = Seq.fill(totalIterations)(Wire(chiselTypeOf(io.in)))
-  val pipelineRegs = Seq.tabulate(totalIterations)(i => RegEnable(outWires(i).bits, outWires(i).valid && io.out.ready))
-  val validRegs    = Seq.tabulate(totalIterations)(i => RegInit(false.B))
+  val pipelineRegs = Seq.tabulate(totalIterations)(i => RegEnable(outWires(i).bits, io.out.ready))
+  val validRegs    = Seq.tabulate(totalIterations)(i => RegEnable(outWires(i).valid, false.B, io.out.ready))
 
-  validRegs.zip(outWires).map { case (validReg, outWire) => validReg := outWire.valid && io.out.ready }
   inWires.foreach(_.ready := false.B)
   outWires.foreach(_.ready := false.B)
   inWires(0).bits  := inRegs

--- a/src/main/scala/CordicTop.scala
+++ b/src/main/scala/CordicTop.scala
@@ -5,7 +5,7 @@
 package cordic
 
 import chisel3._
-import chisel3.util.{ValidIO, log2Ceil, RegEnable}
+import chisel3.util.{DecoupledIO, log2Ceil, RegEnable, Queue}
 import chisel3.stage.{ChiselStage}
 import chisel3.stage.ChiselGeneratorAnnotation
 import chisel3.experimental.ExtModule
@@ -28,21 +28,21 @@ case class CordicTopIO(
   useDout: Boolean
   ) extends Bundle {
 
-  val in = Input(ValidIO(new Bundle {
+  val in = Flipped(DecoupledIO(new Bundle {
     val rs1     = if (useIn1) Some(SInt(dataWidth.W)) else None
     val rs2     = if (useIn2) Some(SInt(dataWidth.W)) else None
     val rs3     = if (useIn3) Some(SInt(dataWidth.W)) else None
     val control = UInt(32.W)
   }))
 
-  val out = Output(ValidIO(new Bundle {
+  val out = DecoupledIO(new Bundle {
     val cordic = new Bundle {
       val x = if (useOut1) Some(SInt(dataWidth.W)) else None
       val y = if (useOut2) Some(SInt(dataWidth.W)) else None
       val z = if (useOut3) Some(SInt(dataWidth.W)) else None
     }
     val dOut   = if (useDout) Some(SInt(dataWidth.W)) else None
-  }))
+  })
 
 }
 
@@ -106,35 +106,34 @@ class CordicTop
                                          config.enableRotational,
                                          config.enableVectoring))
 
-  val inRegs      = RegEnable(io.in.bits, io.in.valid)
-  val outRegs     = RegEnable(postprocessor.io.out, cordicCore.io.out.valid)
-  val inValidReg  = RegInit(false.B)
-  val outValidReg = RegInit(false.B)
-  inValidReg  := io.in.valid
-  outValidReg := io.out.valid
+  val inRegs      = Module(new Queue(chiselTypeOf(io.in.bits), 2))
+  val outRegs     = Module(new Queue(chiselTypeOf(io.out.bits), 2))
 
-  preprocessor.io.in.rs1     := inRegs.rs1.getOrElse(0.S)
-  preprocessor.io.in.rs2     := inRegs.rs2.getOrElse(0.S)
-  preprocessor.io.in.rs3     := inRegs.rs3.getOrElse(0.S)
-  preprocessor.io.in.control := inRegs.control
-  preprocessor.io.in.valid   := inValidReg
 
-  cordicCore.io.in.bits  := preprocessor.io.out
-  cordicCore.io.in.valid := inValidReg
 
-  postprocessor.io.in.cordic  := cordicCore.io.out.bits.cordic
-  postprocessor.io.in.control := cordicCore.io.out.bits.control
+  preprocessor.io.in.bits.rs1     := inRegs.io.deq.bits.rs1.getOrElse(0.S)
+  preprocessor.io.in.bits.rs2     := inRegs.io.deq.bits.rs2.getOrElse(0.S)
+  preprocessor.io.in.bits.rs3     := inRegs.io.deq.bits.rs3.getOrElse(0.S)
+  preprocessor.io.in.bits.control := inRegs.io.deq.bits.control
+  preprocessor.io.in.valid        := inRegs.io.deq.valid
+  inRegs.io.deq.ready             := preprocessor.io.in.ready
 
-  outRegs.cordic  := postprocessor.io.out.cordic
-  outRegs.dOut    := postprocessor.io.out.dOut
-  outValidReg     := cordicCore.io.out.valid
+  cordicCore.io.in <> preprocessor.io.out
 
-  if(config.usedOutputs.contains(1)) io.out.bits.cordic.x.get := outRegs.cordic.x
-  if(config.usedOutputs.contains(2)) io.out.bits.cordic.y.get := outRegs.cordic.y
-  if(config.usedOutputs.contains(3)) io.out.bits.cordic.z.get := outRegs.cordic.z
-  if(config.useDout)                 io.out.bits.dOut.get     := outRegs.dOut
+  postprocessor.io.in <> cordicCore.io.out 
 
-  io.out.valid := outValidReg
+  outRegs.io.enq.bits.cordic   := postprocessor.io.out.bits.cordic
+  outRegs.io.enq.valid         := postprocessor.io.out.valid
+  postprocessor.io.out.ready   := outRegs.io.enq.ready
+  if (config.useDout) outRegs.io.enq.bits.dOut.get := postprocessor.io.out.bits.dOut
+
+  if(config.usedOutputs.contains(1)) io.out.bits.cordic.x.get := outRegs.io.deq.bits.cordic.x.get
+  if(config.usedOutputs.contains(2)) io.out.bits.cordic.y.get := outRegs.io.deq.bits.cordic.y.get
+  if(config.usedOutputs.contains(3)) io.out.bits.cordic.z.get := outRegs.io.deq.bits.cordic.z.get
+  if(config.useDout)                 io.out.bits.dOut.get     := outRegs.io.deq.bits.dOut.get
+
+  inRegs.io.enq <> io.in
+  io.out        <> outRegs.io.deq
 
 }
 

--- a/src/main/scala/postprocessor/BasicPostprocessor.scala
+++ b/src/main/scala/postprocessor/BasicPostprocessor.scala
@@ -21,7 +21,9 @@ class BasicPostprocessor(mantissaBits: Int, fractionBits: Int,
                          iterations: Int, repr: String)
   extends CordicPostprocessor(mantissaBits, fractionBits, iterations, repr) {
 
-  io.out.cordic <> io.in.cordic
-  io.out.dOut   := 0.S
+  io.out.bits.cordic <> io.in.bits.cordic
+  io.out.bits.dOut   := 0.S
+  io.out.valid := io.in.valid
+  io.in.ready := io.out.ready
 
 }

--- a/src/main/scala/postprocessor/CordicPostprocessor.scala
+++ b/src/main/scala/postprocessor/CordicPostprocessor.scala
@@ -6,25 +6,25 @@ package cordic
 
 import chisel3._
 import chisel3.experimental._
-import chisel3.util.{MuxCase, log2Ceil}
+import chisel3.util.{MuxCase, log2Ceil, DecoupledIO}
 import chisel3.stage.{ChiselStage}
 import chisel3.stage.ChiselGeneratorAnnotation
 
 case class CordicPostprocessorIO(dataWidth: Int) extends Bundle {
 
-  val in = new Bundle {
+  val in = Flipped(DecoupledIO(new Bundle {
     val cordic  = Input(CordicBundle(dataWidth))
     val control = Input(CordicCoreControl())
-  }
+  }))
 
-  val out = new Bundle {
+  val out = DecoupledIO(new Bundle {
 
     /** Bundle of post processed x, y, and z */
     val cordic = Output(CordicBundle(dataWidth))
 
     /** Additional output signal to be freely used */
     val dOut = Output(SInt(dataWidth.W))
-  }
+  })
 
 }
 

--- a/src/main/scala/postprocessor/TrigFuncPostprocessor.scala
+++ b/src/main/scala/postprocessor/TrigFuncPostprocessor.scala
@@ -21,64 +21,67 @@ class TrigFuncPostprocessor(mantissaBits: Int, fractionBits: Int,
   extends CordicPostprocessor(mantissaBits, fractionBits, iterations, repr) {
 
   // Rescaling needed if it was performed in perprocessor
-  val rescale = io.in.control.custom(TrigFuncControl.LTPO2) || io.in.control.custom(TrigFuncControl.STNPO2)
+  val rescale = io.in.bits.control.custom(TrigFuncControl.LTPO2) || io.in.bits.control.custom(TrigFuncControl.STNPO2)
 
   // Either x or y needs to be rescaled, depending on SINE or COSINE operation
   val adderA = WireDefault(0.S)
-  when (io.in.control.custom(31,2) === TrigOp.SINE.asUInt) {
-    adderA := ~io.in.cordic.y
-  } .elsewhen(io.in.control.custom(31,2) === TrigOp.COSINE.asUInt) {
-    adderA := ~io.in.cordic.x
+  when (io.in.bits.control.custom(31,2) === TrigOp.SINE.asUInt) {
+    adderA := ~io.in.bits.cordic.y
+  } .elsewhen(io.in.bits.control.custom(31,2) === TrigOp.COSINE.asUInt) {
+    adderA := ~io.in.bits.cordic.x
   }
 
   // Rescale from negative to positive, or vice versa
   val rescaled = adderA + 1.S
 
-  when (io.in.control.custom(31,2) === TrigOp.SINE.asUInt) {
-    io.out.cordic.x := io.in.cordic.x
-    io.out.cordic.y := Mux(rescale, rescaled, io.in.cordic.y)
-    io.out.cordic.z := io.in.cordic.z
-    io.out.dOut     := io.out.cordic.y
-  } .elsewhen(io.in.control.custom(31,2) === TrigOp.COSINE.asUInt) {
-    io.out.cordic.x := Mux(rescale, rescaled, io.in.cordic.x)
-    io.out.cordic.y := io.in.cordic.y
-    io.out.cordic.z := io.in.cordic.z
-    io.out.dOut     := io.out.cordic.x
-  } .elsewhen(io.in.control.custom(31,2) === TrigOp.ARCTAN.asUInt) {
-    io.out.cordic.x := io.in.cordic.x
-    io.out.cordic.y := io.in.cordic.y
-    io.out.cordic.z := io.in.cordic.z
-    io.out.dOut     := io.out.cordic.z
-  } .elsewhen(io.in.control.custom(31,2) === TrigOp.SINH.asUInt) {
-    io.out.cordic.x := io.in.cordic.x
-    io.out.cordic.y := io.in.cordic.y
-    io.out.cordic.z := io.in.cordic.z
-    io.out.dOut     := io.out.cordic.y
-  } .elsewhen(io.in.control.custom(31,2) === TrigOp.COSH.asUInt) {
-    io.out.cordic.x := io.in.cordic.x
-    io.out.cordic.y := io.in.cordic.y
-    io.out.cordic.z := io.in.cordic.z
-    io.out.dOut     := io.out.cordic.x
-  } .elsewhen(io.in.control.custom(31,2) === TrigOp.ARCTANH.asUInt) {
-    io.out.cordic.x := io.in.cordic.x
-    io.out.cordic.y := io.in.cordic.y
-    io.out.cordic.z := io.in.cordic.z
-    io.out.dOut     := io.out.cordic.z
-  } .elsewhen(io.in.control.custom(31,2) === TrigOp.EXPONENTIAL.asUInt) {
-    io.out.cordic.x := io.in.cordic.x
-    io.out.cordic.y := io.in.cordic.y
-    io.out.cordic.z := io.in.cordic.z
-    io.out.dOut     := io.out.cordic.x
-  } .elsewhen(io.in.control.custom(31,2) === TrigOp.LOG.asUInt) {
-    io.out.cordic.x := io.in.cordic.x
-    io.out.cordic.y := io.in.cordic.y
-    io.out.cordic.z := io.in.cordic.z
+  when (io.in.bits.control.custom(31,2) === TrigOp.SINE.asUInt) {
+    io.out.bits.cordic.x := io.in.bits.cordic.x
+    io.out.bits.cordic.y := Mux(rescale, rescaled, io.in.bits.cordic.y)
+    io.out.bits.cordic.z := io.in.bits.cordic.z
+    io.out.bits.dOut     := io.out.bits.cordic.y
+  } .elsewhen(io.in.bits.control.custom(31,2) === TrigOp.COSINE.asUInt) {
+    io.out.bits.cordic.x := Mux(rescale, rescaled, io.in.bits.cordic.x)
+    io.out.bits.cordic.y := io.in.bits.cordic.y
+    io.out.bits.cordic.z := io.in.bits.cordic.z
+    io.out.bits.dOut     := io.out.bits.cordic.x
+  } .elsewhen(io.in.bits.control.custom(31,2) === TrigOp.ARCTAN.asUInt) {
+    io.out.bits.cordic.x := io.in.bits.cordic.x
+    io.out.bits.cordic.y := io.in.bits.cordic.y
+    io.out.bits.cordic.z := io.in.bits.cordic.z
+    io.out.bits.dOut     := io.out.bits.cordic.z
+  } .elsewhen(io.in.bits.control.custom(31,2) === TrigOp.SINH.asUInt) {
+    io.out.bits.cordic.x := io.in.bits.cordic.x
+    io.out.bits.cordic.y := io.in.bits.cordic.y
+    io.out.bits.cordic.z := io.in.bits.cordic.z
+    io.out.bits.dOut     := io.out.bits.cordic.y
+  } .elsewhen(io.in.bits.control.custom(31,2) === TrigOp.COSH.asUInt) {
+    io.out.bits.cordic.x := io.in.bits.cordic.x
+    io.out.bits.cordic.y := io.in.bits.cordic.y
+    io.out.bits.cordic.z := io.in.bits.cordic.z
+    io.out.bits.dOut     := io.out.bits.cordic.x
+  } .elsewhen(io.in.bits.control.custom(31,2) === TrigOp.ARCTANH.asUInt) {
+    io.out.bits.cordic.x := io.in.bits.cordic.x
+    io.out.bits.cordic.y := io.in.bits.cordic.y
+    io.out.bits.cordic.z := io.in.bits.cordic.z
+    io.out.bits.dOut     := io.out.bits.cordic.z
+  } .elsewhen(io.in.bits.control.custom(31,2) === TrigOp.EXPONENTIAL.asUInt) {
+    io.out.bits.cordic.x := io.in.bits.cordic.x
+    io.out.bits.cordic.y := io.in.bits.cordic.y
+    io.out.bits.cordic.z := io.in.bits.cordic.z
+    io.out.bits.dOut     := io.out.bits.cordic.x
+  } .elsewhen(io.in.bits.control.custom(31,2) === TrigOp.LOG.asUInt) {
+    io.out.bits.cordic.x := io.in.bits.cordic.x
+    io.out.bits.cordic.y := io.in.bits.cordic.y
+    io.out.bits.cordic.z := io.in.bits.cordic.z
     // CORDIC returns 0.5*log - this multiplies by 2
-    io.out.dOut     := io.out.cordic.z << 1
+    io.out.bits.dOut     := io.out.bits.cordic.z << 1
   } .otherwise {
-    io.out.cordic.x := DontCare
-    io.out.cordic.y := DontCare
-    io.out.cordic.z := DontCare
-    io.out.dOut     := DontCare
+    io.out.bits.cordic.x := DontCare
+    io.out.bits.cordic.y := DontCare
+    io.out.bits.cordic.z := DontCare
+    io.out.bits.dOut     := DontCare
   }
+
+  io.out.valid := io.in.valid
+  io.in.ready := io.out.ready
 }

--- a/src/main/scala/preprocessor/BasicPreprocessor.scala
+++ b/src/main/scala/preprocessor/BasicPreprocessor.scala
@@ -22,13 +22,16 @@ class BasicPreprocessor(mantissaBits: Int, fractionBits: Int,
                            iterations: Int, repr: String)
   extends CordicPreprocessor(mantissaBits, fractionBits, iterations, repr) {
 
-  io.out.cordic.x := io.in.rs1
-  io.out.cordic.y := io.in.rs2
-  io.out.cordic.z := io.in.rs3
+  io.out.bits.cordic.x := io.in.bits.rs1
+  io.out.bits.cordic.y := io.in.bits.rs2
+  io.out.bits.cordic.z := io.in.bits.rs3
 
-  io.out.control.rotType := Mux(io.in.control(0), CordicRotationType.HYPERBOLIC, CordicRotationType.CIRCULAR)
-  io.out.control.mode    := Mux(io.in.control(1), CordicMode.VECTORING, CordicMode.ROTATION)
-  io.out.control.custom  := 0.U
+  io.out.bits.control.rotType := Mux(io.in.bits.control(0), CordicRotationType.HYPERBOLIC, CordicRotationType.CIRCULAR)
+  io.out.bits.control.mode    := Mux(io.in.bits.control(1), CordicMode.VECTORING, CordicMode.ROTATION)
+  io.out.bits.control.custom  := 0.U
+
+  io.out.valid := io.in.valid
+  io.in.ready  := io.out.ready
 
 }
 

--- a/src/main/scala/preprocessor/CordicPreprocessor.scala
+++ b/src/main/scala/preprocessor/CordicPreprocessor.scala
@@ -6,13 +6,13 @@ package cordic
 
 import chisel3._
 import chisel3.experimental._
-import chisel3.util.{MuxCase, log2Ceil}
+import chisel3.util.{MuxCase, log2Ceil, DecoupledIO}
 import chisel3.stage.{ChiselStage}
 import chisel3.stage.ChiselGeneratorAnnotation
 
 case class CordicPreprocessorIO(dataWidth: Int) extends Bundle {
 
-  val in = new Bundle {
+  val in = Flipped(DecoupledIO(new Bundle {
     /** Source register 1 */
     val rs1     = Input(SInt(dataWidth.W))
     /** Source register 2 */
@@ -21,16 +21,14 @@ case class CordicPreprocessorIO(dataWidth: Int) extends Bundle {
     val rs3     = Input(SInt(dataWidth.W))
     /** Control bits */
     val control = Input(UInt())
-    /** Indicates new input data */
-    val valid   = Input(Bool())
-  }
+  }))
 
-  val out = new Bundle {
+  val out = DecoupledIO(new Bundle {
     /** Outputs to CordicCore */
     val cordic  = Output(CordicBundle(dataWidth))
     /** Control bundle */
     val control = Output(CordicCoreControl())
-  }
+  })
 
 }
 

--- a/src/main/scala/preprocessor/TrigFuncPreprocessor.scala
+++ b/src/main/scala/preprocessor/TrigFuncPreprocessor.scala
@@ -39,8 +39,8 @@ class TrigFuncPreprocessor(mantissaBits: Int, fractionBits: Int,
                            iterations: Int, repr: String)
   extends CordicPreprocessor(mantissaBits, fractionBits, iterations, repr) {
 
-  val largerThanPiOver2     = io.in.rs1 > consts.pPiOver2
-  val smallerThanNegPiOver2 = io.in.rs1 < consts.nPiOver2
+  val largerThanPiOver2     = io.in.bits.rs1 > consts.pPiOver2
+  val smallerThanNegPiOver2 = io.in.bits.rs1 < consts.nPiOver2
 
   // Adder needed for
   // Rescaling Sin and Cos to improve range
@@ -52,78 +52,81 @@ class TrigFuncPreprocessor(mantissaBits: Int, fractionBits: Int,
   val subB = WireDefault(0.S)
 
   // Mux for adder input
-  when ((io.in.control === TrigOp.SINE.asUInt) || (io.in.control === TrigOp.COSINE.asUInt)) {
-    addA := io.in.rs1
+  when ((io.in.bits.control === TrigOp.SINE.asUInt) || (io.in.bits.control === TrigOp.COSINE.asUInt)) {
+    addA := io.in.bits.rs1
     addB := consts.pPi
-    subA := io.in.rs1
+    subA := io.in.bits.rs1
     subB := consts.pPi
-  } .elsewhen (io.in.control === TrigOp.LOG.asUInt) {
-    addA := io.in.rs1
+  } .elsewhen (io.in.bits.control === TrigOp.LOG.asUInt) {
+    addA := io.in.bits.rs1
     addB := CordicMethods.toFixedPoint(1.0, mantissaBits, fractionBits, repr)
-    subA := io.in.rs1
+    subA := io.in.bits.rs1
     subB := CordicMethods.toFixedPoint(1.0, mantissaBits, fractionBits, repr)
   }
 
   val adder = addA + addB
   val subtractor = subA - subB
 
-  when (io.in.control === TrigOp.SINE.asUInt) {
-    io.out.cordic.x := consts.K
-    io.out.cordic.y := 0.S
-    io.out.cordic.z := MuxCase(io.in.rs1, Seq(largerThanPiOver2 -> subtractor, smallerThanNegPiOver2 -> adder))
-    io.out.control.rotType := CordicRotationType.CIRCULAR
-    io.out.control.mode := CordicMode.ROTATION
-  } .elsewhen (io.in.control === TrigOp.COSINE.asUInt) {
-    io.out.cordic.x := consts.K
-    io.out.cordic.y := 0.S
-    io.out.cordic.z := MuxCase(io.in.rs1, Seq(largerThanPiOver2 -> subtractor, smallerThanNegPiOver2 -> adder))
-    io.out.control.rotType := CordicRotationType.CIRCULAR
-    io.out.control.mode := CordicMode.ROTATION
-  } .elsewhen (io.in.control === TrigOp.ARCTAN.asUInt) {
-    io.out.cordic.x := CordicMethods.toFixedPoint(1.0, mantissaBits, fractionBits, repr)
-    io.out.cordic.y := io.in.rs1
-    io.out.cordic.z := 0.S
-    io.out.control.rotType := CordicRotationType.CIRCULAR
-    io.out.control.mode := CordicMode.VECTORING
-  } .elsewhen (io.in.control === TrigOp.SINH.asUInt) {
-    io.out.cordic.x := consts.Kh
-    io.out.cordic.y := 0.S
-    io.out.cordic.z := io.in.rs1
-    io.out.control.rotType := CordicRotationType.HYPERBOLIC
-    io.out.control.mode := CordicMode.ROTATION
-  } .elsewhen (io.in.control === TrigOp.COSH.asUInt) {
-    io.out.cordic.x := consts.Kh
-    io.out.cordic.y := 0.S
-    io.out.cordic.z := io.in.rs1
-    io.out.control.rotType := CordicRotationType.HYPERBOLIC
-    io.out.control.mode := CordicMode.ROTATION
-  } .elsewhen (io.in.control === TrigOp.ARCTANH.asUInt) {
-    io.out.cordic.x := CordicMethods.toFixedPoint(1.0, mantissaBits, fractionBits, repr)
-    io.out.cordic.y := io.in.rs1
-    io.out.cordic.z := 0.S
-    io.out.control.rotType := CordicRotationType.HYPERBOLIC
-    io.out.control.mode := CordicMode.VECTORING
-  } .elsewhen (io.in.control === TrigOp.EXPONENTIAL.asUInt) {
-    io.out.cordic.x := consts.Kh
-    io.out.cordic.y := consts.Kh
-    io.out.cordic.z := io.in.rs1
-    io.out.control.rotType := CordicRotationType.HYPERBOLIC
-    io.out.control.mode := CordicMode.ROTATION
-  } .elsewhen (io.in.control === TrigOp.LOG.asUInt) {
-    io.out.cordic.x := adder
-    io.out.cordic.y := subtractor
-    io.out.cordic.z := 0.S
-    io.out.control.rotType := CordicRotationType.HYPERBOLIC
-    io.out.control.mode := CordicMode.VECTORING
+  when (io.in.bits.control === TrigOp.SINE.asUInt) {
+    io.out.bits.cordic.x := consts.K
+    io.out.bits.cordic.y := 0.S
+    io.out.bits.cordic.z := MuxCase(io.in.bits.rs1, Seq(largerThanPiOver2 -> subtractor, smallerThanNegPiOver2 -> adder))
+    io.out.bits.control.rotType := CordicRotationType.CIRCULAR
+    io.out.bits.control.mode := CordicMode.ROTATION
+  } .elsewhen (io.in.bits.control === TrigOp.COSINE.asUInt) {
+    io.out.bits.cordic.x := consts.K
+    io.out.bits.cordic.y := 0.S
+    io.out.bits.cordic.z := MuxCase(io.in.bits.rs1, Seq(largerThanPiOver2 -> subtractor, smallerThanNegPiOver2 -> adder))
+    io.out.bits.control.rotType := CordicRotationType.CIRCULAR
+    io.out.bits.control.mode := CordicMode.ROTATION
+  } .elsewhen (io.in.bits.control === TrigOp.ARCTAN.asUInt) {
+    io.out.bits.cordic.x := CordicMethods.toFixedPoint(1.0, mantissaBits, fractionBits, repr)
+    io.out.bits.cordic.y := io.in.bits.rs1
+    io.out.bits.cordic.z := 0.S
+    io.out.bits.control.rotType := CordicRotationType.CIRCULAR
+    io.out.bits.control.mode := CordicMode.VECTORING
+  } .elsewhen (io.in.bits.control === TrigOp.SINH.asUInt) {
+    io.out.bits.cordic.x := consts.Kh
+    io.out.bits.cordic.y := 0.S
+    io.out.bits.cordic.z := io.in.bits.rs1
+    io.out.bits.control.rotType := CordicRotationType.HYPERBOLIC
+    io.out.bits.control.mode := CordicMode.ROTATION
+  } .elsewhen (io.in.bits.control === TrigOp.COSH.asUInt) {
+    io.out.bits.cordic.x := consts.Kh
+    io.out.bits.cordic.y := 0.S
+    io.out.bits.cordic.z := io.in.bits.rs1
+    io.out.bits.control.rotType := CordicRotationType.HYPERBOLIC
+    io.out.bits.control.mode := CordicMode.ROTATION
+  } .elsewhen (io.in.bits.control === TrigOp.ARCTANH.asUInt) {
+    io.out.bits.cordic.x := CordicMethods.toFixedPoint(1.0, mantissaBits, fractionBits, repr)
+    io.out.bits.cordic.y := io.in.bits.rs1
+    io.out.bits.cordic.z := 0.S
+    io.out.bits.control.rotType := CordicRotationType.HYPERBOLIC
+    io.out.bits.control.mode := CordicMode.VECTORING
+  } .elsewhen (io.in.bits.control === TrigOp.EXPONENTIAL.asUInt) {
+    io.out.bits.cordic.x := consts.Kh
+    io.out.bits.cordic.y := consts.Kh
+    io.out.bits.cordic.z := io.in.bits.rs1
+    io.out.bits.control.rotType := CordicRotationType.HYPERBOLIC
+    io.out.bits.control.mode := CordicMode.ROTATION
+  } .elsewhen (io.in.bits.control === TrigOp.LOG.asUInt) {
+    io.out.bits.cordic.x := adder
+    io.out.bits.cordic.y := subtractor
+    io.out.bits.cordic.z := 0.S
+    io.out.bits.control.rotType := CordicRotationType.HYPERBOLIC
+    io.out.bits.control.mode := CordicMode.VECTORING
   } .otherwise {
-    io.out.cordic.x := DontCare
-    io.out.cordic.y := DontCare
-    io.out.cordic.z := DontCare
-    io.out.control.rotType := CordicRotationType.CIRCULAR
-    io.out.control.mode := CordicMode.ROTATION
+    io.out.bits.cordic.x := DontCare
+    io.out.bits.cordic.y := DontCare
+    io.out.bits.cordic.z := DontCare
+    io.out.bits.control.rotType := CordicRotationType.CIRCULAR
+    io.out.bits.control.mode := CordicMode.ROTATION
   }
 
-  io.out.control.custom := Cat(io.in.control, largerThanPiOver2, smallerThanNegPiOver2)
+  io.out.bits.control.custom := Cat(io.in.bits.control, largerThanPiOver2, smallerThanNegPiOver2)
+
+  io.out.valid := io.in.valid
+  io.in.ready  := io.out.ready
 
 }
 

--- a/src/main/scala/preprocessor/UpConvertPreprocessor.scala
+++ b/src/main/scala/preprocessor/UpConvertPreprocessor.scala
@@ -28,7 +28,7 @@ class UpConvertPreprocessor(mantissaBits: Int, fractionBits: Int,
   val controlWord = io.in.bits.control.asSInt
 
   if (config.usePhaseAccum) {
-    when (io.in.valid) {
+    when (io.out.fire) {
       phaseAccum := phaseAccum + controlWord
     }
   }

--- a/src/main/scala/preprocessor/UpConvertPreprocessor.scala
+++ b/src/main/scala/preprocessor/UpConvertPreprocessor.scala
@@ -25,7 +25,7 @@ class UpConvertPreprocessor(mantissaBits: Int, fractionBits: Int,
 
   val phaseAccum = RegInit(0.S(config.phaseAccumWidth.W))
   // Control word sets the frequency
-  val controlWord = io.in.control.asSInt
+  val controlWord = io.in.bits.control.asSInt
 
   if (config.usePhaseAccum) {
     when (io.in.valid) {
@@ -36,7 +36,7 @@ class UpConvertPreprocessor(mantissaBits: Int, fractionBits: Int,
   // Use MSB bits for phase value
   val phase = {
     if (config.usePhaseAccum) phaseAccum.head(mantissaBits + fractionBits).asSInt
-    else io.in.rs3
+    else io.in.bits.rs3
   }
 
   // TODO: check if it should be >= or <= for efficient hw
@@ -59,15 +59,18 @@ class UpConvertPreprocessor(mantissaBits: Int, fractionBits: Int,
   val adder = addA + addB
   val subtractor = subA - subB
 
-  val rs1_neg = ~io.in.rs1 + 1.S
-  val rs2_neg = ~io.in.rs2 + 1.S
+  val rs1_neg = ~io.in.bits.rs1 + 1.S
+  val rs2_neg = ~io.in.bits.rs2 + 1.S
 
-  io.out.cordic.x := MuxCase(io.in.rs1, Seq(largerThanPiOver2 -> rs2_neg, smallerThanNegPiOver2 -> io.in.rs2))
-  io.out.cordic.y := MuxCase(io.in.rs2, Seq(largerThanPiOver2 -> io.in.rs1, smallerThanNegPiOver2 -> rs1_neg))
-  io.out.cordic.z := MuxCase(phase, Seq(largerThanPiOver2 -> subtractor, smallerThanNegPiOver2 -> adder))
-  io.out.control.rotType := CordicRotationType.CIRCULAR
-  io.out.control.mode := CordicMode.ROTATION
+  io.out.bits.cordic.x := MuxCase(io.in.bits.rs1, Seq(largerThanPiOver2 -> rs2_neg, smallerThanNegPiOver2 -> io.in.bits.rs2))
+  io.out.bits.cordic.y := MuxCase(io.in.bits.rs2, Seq(largerThanPiOver2 -> io.in.bits.rs1, smallerThanNegPiOver2 -> rs1_neg))
+  io.out.bits.cordic.z := MuxCase(phase, Seq(largerThanPiOver2 -> subtractor, smallerThanNegPiOver2 -> adder))
+  io.out.bits.control.rotType := CordicRotationType.CIRCULAR
+  io.out.bits.control.mode := CordicMode.ROTATION
 
-  io.out.control.custom := 0.U
+  io.out.bits.control.custom := 0.U
+
+  io.out.valid := io.in.valid
+  io.in.ready := io.out.ready
 
 }

--- a/src/test/cocotb/CordicCore/Makefile
+++ b/src/test/cocotb/CordicCore/Makefile
@@ -8,7 +8,7 @@ TOPLEVEL_LANG ?= verilog
 # TOPLEVEL is the name of the toplevel module in your Verilog or VHDL file
 TOPLEVEL = CordicCore
 
-VERILOG_SOURCES += $(PWD)/../../../../verilog/$(TOPLEVEL).sv
+VERILOG_SOURCES += $(PWD)/../../../../verilog/$(TOPLEVEL).v
 # use VHDL_SOURCES for VHDL files
 
 # MODULE is the basename of the Python test file
@@ -17,8 +17,8 @@ MODULE = test_$(TOPLEVEL)
 # include cocotb's make rules to take care of the simulator setup
 include $(shell cocotb-config --makefiles)/Makefile.sim
 
-%.sv:
-	cd $(PWD)/../../../.. && ./configure && $(MAKE) $(TOPLEVEL)
+%.v:
+	cd $(PWD)/../../../.. && ./configure && make clean && make $(TOPLEVEL)
 
 clean_vlog:
 	rm $(VERILOG_SOURCES)

--- a/src/test/cocotb/CordicCore/test_CordicCore.py
+++ b/src/test/cocotb/CordicCore/test_CordicCore.py
@@ -26,16 +26,17 @@ async def test_circ_rot_operation(dut):
     dut.io_in_bits_control_mode.value = 0
     dut.io_in_bits_control_rotType.value = 0
     dut.io_in_valid.value = 1
+    dut.io_out_ready.value = 1
     await RisingEdge(dut.clock)
     dut.io_in_valid.value = 0
 
-    await ClockCycles(dut.clock, 20)
+    await ClockCycles(dut.clock, 19)
     assert dut.io_out_valid == 1, f"Valid should be 1, was {dut.io_out_valid}"
-    assert dut.io_out_bits_y.value.signed_integer in [
+    assert dut.io_out_bits_cordic_y.value.signed_integer in [
         -1,
         0,
         1,
-    ], f"Y should be zero +- 1, was {dut.io_out_bits_y.value}"
+    ], f"Y should be zero +- 1, was {dut.io_out_bits_cordic_y.value}"
 
 
 @cocotb.test()
@@ -61,14 +62,15 @@ async def test_circ_vec_operation(dut):
     dut.io_in_bits_control_mode.value = 1
     dut.io_in_bits_control_rotType.value = 0
     dut.io_in_valid.value = 1
+    dut.io_out_ready.value = 1
     await RisingEdge(dut.clock)
     dut.io_in_valid.value = 0
 
-    await ClockCycles(dut.clock, 20)
+    await ClockCycles(dut.clock, 19)
     assert dut.io_out_valid == 1, f"Valid should be 1, was {dut.io_out_valid}"
-    assert dut.io_out_bits_y.value.signed_integer in [
+    assert dut.io_out_bits_cordic_y.value.signed_integer in [
         -3, -2, -1, 0, 1, 2, 3
-    ], f"Y should be zero +- 3, was {dut.io_out_bits_y.value}"
+    ], f"Y should be zero +- 3, was {dut.io_out_bits_cordic_y.value}"
 
 
 @cocotb.test()
@@ -94,14 +96,15 @@ async def test_hyper_rot_operation(dut):
     dut.io_in_bits_control_mode.value = 0
     dut.io_in_bits_control_rotType.value = 1
     dut.io_in_valid.value = 1
+    dut.io_out_ready.value = 1
     await RisingEdge(dut.clock)
     dut.io_in_valid.value = 0
 
-    await ClockCycles(dut.clock, 20)
+    await ClockCycles(dut.clock, 19)
     assert dut.io_out_valid == 1, f"Valid should be 1, was {dut.io_out_valid}"
-    assert dut.io_out_bits_z.value.signed_integer in [
+    assert dut.io_out_bits_cordic_z.value.signed_integer in [
         -1, 0, 1
-    ], f"Z should be zero +- 1, was {dut.io_out_bits_z.value}"
+    ], f"Z should be zero +- 1, was {dut.io_out_bits_cordic_z.value}"
 
 
 @cocotb.test()
@@ -127,11 +130,12 @@ async def test_hyper_vec_operation(dut):
     dut.io_in_bits_control_mode.value = 1
     dut.io_in_bits_control_rotType.value = 1
     dut.io_in_valid.value = 1
+    dut.io_out_ready.value = 1
     await RisingEdge(dut.clock)
     dut.io_in_valid.value = 0
 
-    await ClockCycles(dut.clock, 20)
+    await ClockCycles(dut.clock, 19)
     assert dut.io_out_valid == 1, f"Valid should be 1, was {dut.io_out_valid}"
-    assert dut.io_out_bits_y.value.signed_integer in [
+    assert dut.io_out_bits_cordic_y.value.signed_integer in [
         -1, 0, 1
-    ], f"Y should be zero +- 1, was {dut.io_out_bits_y.value}"
+    ], f"Y should be zero +- 1, was {dut.io_out_bits_cordic_y.value}"


### PR DESCRIPTION
Add `ready` signal to both input and output.

This allows full sample-by-sample flow control.

Added a 2-deep FIFO on both input and output. When output FIFO is full, the CordicCore pipeline is stalled.